### PR TITLE
Support scala cross-version scheme in artifactId #5 #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ project_id=55db6cf87a7c24000c03943d
 | skipScopes                    | Comma separated list of scopes which should be ignored by this plugin (e.g. compile, provided)|
 | updatePropertiesAfterCreate   | updatePropertiesAfterCreate |
 | filterScalaLangDependencies   | By default the scala-library dependency is not tracked. The scala-library dependency can be enabled for tracking by setting this property to `false`. |
+| publishCrossVersion           | Append Scala binary version to the artifact_id when publishing this project if set to `true` |
 
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 sbtPlugin := true
 organization := "com.versioneye"
 name := "sbt-versioneye-plugin"
-version := "0.1.0"
+version := "0.1.1-SNAPSHOT"
 organizationHomepage := Some(new URL("https://www.versioneye.com"))
 description := "This is the sbt plugin for https://www.VersionEye.com. It allows you to create and update a project at VersionEye. You can find a complete documentation of this project on GitHub: https://github.com/versioneye/versioneye_sbt_plugin."
 startYear := Some(2015)


### PR DESCRIPTION
Append scala binary version to dependencies for cross-version build. The plugin supports only the current scala version (`scalaVersion` from the sbt file) and allows to append the scala binary version also to the project artifact Id (`publishCrossVersion`).
