### PR TITLE
Read API Key from ENV variable/system properties #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ Creates a `pom.json` file in the `target` dir (usually `target/pom.json`).
 
 ## API Key
 
-This plugin can obtain the API key from any of the following property files (in this precedence):
+This plugin can obtain the API key from any of the following property sources (in this precedence):
 
-1. Configured property file in the SBT build (`apiKey in versioneye := "myApiKey"`)
-2. Configured property file in the SBT build (`propertyPath in versioneye := "myfile.properties"`)
-3. `src/qa/resources/versioneye.properties`
-4. `src/main/resources/versioneye.properties`
-5. `${HOME}/.m2/versioneye.properties`
+1. Set `VERSIONEYE_API_KEY=myApiKey` environment variable or the `versioneye.api.key=myApiKey` system property.
+2. Configured property file in the SBT build (`apiKey in versioneye := "myApiKey"`)
+3. Configured property file in the SBT build (`propertyPath in versioneye := "myfile.properties"`)
+4. `src/qa/resources/versioneye.properties`
+5. `src/main/resources/versioneye.properties`
+6. `${HOME}/.m2/versioneye.properties`
 
 Properties example:
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 sbtPlugin := true
 organization := "com.versioneye"
 name := "sbt-versioneye-plugin"
-version := "0.1.1"
+version := "0.2.0-SNAPSHOT"
 organizationHomepage := Some(new URL("https://www.versioneye.com"))
 description := "This is the sbt plugin for https://www.VersionEye.com. It allows you to create and update a project at VersionEye. You can find a complete documentation of this project on GitHub: https://github.com/versioneye/versioneye_sbt_plugin."
 startYear := Some(2015)


### PR DESCRIPTION
The API key can be configured either in the VERSIONEYE_API_KEY environment variable or the versioneye.api.key system property to override settings from the property files/SBT configuration. The API key can be set in the environment variable and the system property but the plugin will fail if the value is different.
