### PR TITLE
Use configured baseUrl in versioneye.properties header #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ Creates a `pom.json` file in the `target` dir (usually `target/pom.json`).
 
 ## API Key
 
-This plugin can obtain the API key from any of the following property files (in this precedence):
+This plugin can obtain the API key from any of the following property sources (in this precedence):
 
-1. Configured property file in the SBT build (`apiKey in versioneye := "myApiKey"`)
-2. Configured property file in the SBT build (`propertyPath in versioneye := "myfile.properties"`)
-3. `src/qa/resources/versioneye.properties`
-4. `src/main/resources/versioneye.properties`
-5. `${HOME}/.m2/versioneye.properties`
+1. Set `VERSIONEYE_API_KEY=myApiKey` environment variable or the `versioneye.api.key=myApiKey` system property.
+2. Configured property file in the SBT build (`apiKey in versioneye := "myApiKey"`)
+3. Configured property file in the SBT build (`propertyPath in versioneye := "myfile.properties"`)
+4. `src/qa/resources/versioneye.properties`
+5. `src/main/resources/versioneye.properties`
+6. `${HOME}/.m2/versioneye.properties`
 
 Properties example:
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,18 @@ Compile it:
 sbt compile
 ```
 
-Enable it within your `build.sbt`
+Enable it within your `build.sbt` and optionally set properties:
 
 ```
 enablePlugins(VersionEyePlugin)
+
+// VersionEyePlugin.projectSettings
+propertiesPath in versioneye := "/Users/mark/playground/sbt-test/src/qa/resources/versioneye.properties"
+apiKey in versioneye := "myApiKey"
+baseUrl in versioneye := "https://www.versioneye.com"
+apiPath in versioneye := "/api/v2"
+publishCrossVersion in versioneye := true
+
 ```
 
 ## Create a VersionEye project

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 sbtPlugin := true
 organization := "com.versioneye"
 name := "sbt-versioneye-plugin"
-version := "0.1.1"
+version := "0.2.0-SNAPSHOT"
 organizationHomepage := Some(new URL("https://www.versioneye.com"))
 description := "This is the sbt plugin for https://www.VersionEye.com. It allows you to create and update a project at VersionEye. You can find a complete documentation of this project on GitHub: https://github.com/versioneye/versioneye_sbt_plugin."
 startYear := Some(2015)

--- a/src/main/scala/com/versioneye/PropertiesUtil.scala
+++ b/src/main/scala/com/versioneye/PropertiesUtil.scala
@@ -12,7 +12,7 @@ object PropertiesUtil {
 
   protected val propertiesFile: String = "versioneye.properties"
 
-  def writeProperties(response: ProjectJsonResponse, propertiesFile: File): Unit = {
+  def writeProperties(response: ProjectJsonResponse, propertiesFile: File, baseUrl: String): Unit = {
     var properties: Properties = null
 
     if (!propertiesFile.exists()) {
@@ -23,13 +23,12 @@ object PropertiesUtil {
       properties = loadProperties(propertiesFile)
     }
 
-
     if (response.getId != null) {
       properties.setProperty("project_id", response.getId)
     }
 
     val fos = new FileOutputStream(propertiesFile)
-    properties.store(fos, " Properties for https://www.VersionEye.com")
+    properties.store(fos, s" Properties for $baseUrl")
     fos.close()
   }
 


### PR DESCRIPTION
Print the configured URI in the progress log messages. Add documentation for the plugin usage. Improve error message handling.
